### PR TITLE
Fix: Add Procfile for Railway Deployment

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: uvicorn main:app --host 0.0.0.0 --port $PORT


### PR DESCRIPTION
Adds a Procfile to explicitly define the startup command for the FastAPI application on Railway, resolving the 502 Bad Gateway error.